### PR TITLE
#115 - restructure development documentation

### DIFF
--- a/src/main/asciidoc/developer_documentation.adoc
+++ b/src/main/asciidoc/developer_documentation.adoc
@@ -1,3 +1,8 @@
+= Entwicklerdokumentation
+:project_name: name-des-projekts
+:toc: left
+:numbered:
+
 [options="header"]
 [cols="1, 3, 3"]
 |===
@@ -5,16 +10,14 @@
 |...	| ... | ...
 |===
 
-= Entwicklerdokumentation
 
-== Einführung und Ziele
+== Einführung
 * Aufgabenstellung
-* Qualitätsziele
 
 == Randbedingungen
 * Hardware-Vorgaben
 * Software-Vorgaben
-* Vorgaben zum Betrieb des Software
+* Vorgaben zum Betrieb der Software
 
 == Kontextabgrenzung
 * Kontextdiagramm

--- a/src/main/asciidoc/pflichtenheft.adoc
+++ b/src/main/asciidoc/pflichtenheft.adoc
@@ -1,6 +1,7 @@
-= Pflichtenheft
-:project_name: Projektname
-== __{project_name}__
+:project_name: Name des Projekts
+:toc: left
+:numbered:
+= Pflichtenheft __{project_name}__
 
 [options="header"]
 [cols="1, 1, 1, 1, 4"]
@@ -111,11 +112,16 @@ Dieser Abschnitt stellt eine Vereinigung von Glossar und der Beschreibung von Kl
 |===
 
 == Akzeptanztestfälle
-Mithilfe von Akzeptanztests wird geprüft, ob die Software die funktionalen Erwartungen und Anforderungen im Gebrauch erfüllt. Diese sollen und können aus den Anwendungsfallbeschreibungen und den UML-Sequenzdiagrammen abgeleitet werden. D.h., pro (komplexen) Anwendungsfall gibt es typischerweise mindestens ein Sequenzdiagramm (welches ein Szenarium beschreibt). Für jedes Szenarium sollte es einen Akzeptanztestfall geben. Listen Sie alle Akzeptanztestfälle in tabellarischer Form auf.
+Mithilfe von Akzeptanztests wird geprüft, ob die Software die funktionalen Erwartungen und Anforderungen im Gebrauch
+erfüllt.
+Diese sollen und können aus den Anwendungsfallbeschreibungen und den UML-Sequenzdiagrammen abgeleitet werden.
+D.h., pro (komplexen) Anwendungsfall gibt es typischerweise mindestens ein Sequenzdiagramm (, welches ein
+Szenarium beschreibt). Für jedes Szenarium sollte es einen Akzeptanztestfall geben. Listen Sie alle Akzeptanztestfälle in tabellarischer Form auf.
 Jeder Testfall soll mit einer ID versehen werde, um später zwischen den Dokumenten (z.B. im Test-Plan) referenzieren zu können.
 
 == Glossar
-Sämtliche Begriffe, die innerhalb des Projektes verwendet werden und deren gemeinsames Verständnis aller beteiligten Stakeholder essentiell ist, sollten hier aufgeführt werden.
+Sämtliche Begriffe, die innerhalb des Projektes verwendet werden und deren gemeinsames Verständnis aller beteiligten
+Stakeholder essenziell ist, sollten hier aufgeführt werden.
 Insbesondere Begriffe der zu implementierenden Domäne wurden bereits beschrieben, jedoch gibt es meist mehr Begriffe, die einer Beschreibung bedürfen. +
 Beispiel: Was bedeutet "Kunde"? Ein Nutzer des Systems? Der Kunde des Projektes (Auftraggeber)?
 


### PR DESCRIPTION
Fix spelling
Remove the quality goals in dev-doc
Unify the general structure of an adoc (toc, hedline)